### PR TITLE
fix(url normalization): tests failing on windows because of path sep..

### DIFF
--- a/src/nodes/URI.js
+++ b/src/nodes/URI.js
@@ -78,6 +78,7 @@ module.exports = class URI {
             } else {
                 this.uri = path.normalize(rawURI);
             }
+            this.uri = this.uri.replace(/\\/g, '\/');
         } else if (kw.o1 && !isURL) {
             const content = this.asRawString();
             if (content.slice(0, 5) === 'data:') {

--- a/test/regression/uri.js
+++ b/test/regression/uri.js
@@ -30,4 +30,11 @@ describe('URIs', () => {
         );
     });
 
+    it('should handle URL path separator (RFC 3986)', () => {
+        assert.equal(
+          crass.parse('a{foo:url(http://mysite.com/images\\foo//bar\\baz/asdf.jpg)}').optimize({o1: true}).toString(),
+          'a{foo:url(http://mysite.com/images/foo/bar/baz/asdf.jpg)}'
+        );
+    });
+
 });

--- a/test/simple_objects.js
+++ b/test/simple_objects.js
@@ -52,6 +52,13 @@ describe('URIs', () => {
         assert.equal(crass.parse(unnormalized).optimize({o1: true}).toString(), 'a{foo:url(../bar/zap)}');
     });
 
+    it('should normalize URIs handling windows path separator', () => {
+        assert.equal(
+          crass.parse('a{foo:url(\\images/foo\\bar)}').optimize({o1: true}).toString(),
+          'a{foo:url(/images/foo/bar)}'
+        );
+    });
+
 });
 
 


### PR DESCRIPTION
The three tests below were failing on windows because of path normalization:
- URIs should not get all effed up;
- URIs should escape spaces;
- URIs should normalize URIs on O1.

"Since Windows recognizes multiple path separators, both separators will be replaced by instances of the Windows preferred separator ( \\ )" - https://nodejs.org/api/path.html#path_path_normalize_path